### PR TITLE
Fixes #9: Added (*NArray).FillElements

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,6 +176,17 @@ func (n *NArray) SetElement(details []float64, value float64) *NArray {
 	return n
 }
 
+func (n *NArray) FillElements(values []float64) *NArray {
+	if len(n.Data) > len(values) {
+		for i := 0; i < len(values); i++ {
+			n.Data[i] = values[i]
+		}
+	} else {
+		log.Fatal("Cannot accomodate the NArray with the given size of values")
+	}
+	return n
+}
+
 func Range(start, end float64) (n *NArray) {
 	n = Init(end - start)
 	for i := start; i < end; i++ {


### PR DESCRIPTION
- Added (*NArray).FillElements() with values being a float64 array that
would be passed in the argument for the method in order to fill a given
NDArray.

Signed-off-by: AkhilHector <akhilhector.1@gmail.com>